### PR TITLE
Add basic support for Xiaomi outlets

### DIFF
--- a/src/accessories/xiaomi/xiaomi-outlet.ts
+++ b/src/accessories/xiaomi/xiaomi-outlet.ts
@@ -1,0 +1,31 @@
+import { ZigBeeAccessory } from '../zig-bee-accessory';
+import { OutletServiceBuilder } from '../../builders/outlet-service-builder';
+import { PlatformAccessory, Service } from 'homebridge';
+import { ZigbeeNTHomebridgePlatform } from '../../platform';
+import { ZigBeeClient } from '../../zigbee/zig-bee-client';
+import { Device } from 'zigbee-herdsman/dist/controller/model';
+import { DeviceState } from '../../zigbee/types';
+
+export class XiaomiOutlet extends ZigBeeAccessory {
+  private service: Service;
+  constructor(
+    platform: ZigbeeNTHomebridgePlatform,
+    accessory: PlatformAccessory,
+    client: ZigBeeClient,
+    device: Device
+  ) {
+    super(platform, accessory, client, device);
+  }
+
+  getAvailableServices() {
+    this.service = new OutletServiceBuilder(this.platform, this.accessory, this.client, this.state)
+      .withOnOff()
+      .build();
+    return [this.service];
+  }
+
+  update(device: Device, state: DeviceState) {
+    super.update(device, state);
+    this.service.updateCharacteristic(this.platform.Characteristic.On, state.state === 'ON');
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { GledoptoDim } from './accessories/gledopto/gledopto-dim';
 import { TuyaOnoffDoubleSwitch } from './accessories/tuya/tuya-onoff-double-switch';
 import { XiaomiContactSensor } from './accessories/xiaomi/contact-sensor';
 import { XiaomiLightIntensitySensor } from './accessories/xiaomi/light-intensity-sensor';
+import { XiaomiOutlet } from './accessories/xiaomi/xiaomi-outlet';
 import { IkeaRemoteSwitch } from './accessories/ikea/ikea-remote-switch';
 import { IkeaMotionSensor } from './accessories/ikea/ikea-motion-sensor';
 import { LinkindMotionSensor } from './accessories/linkind/linkind-motion-sensor';
@@ -84,6 +85,30 @@ function registerSupportedDevices() {
     ['E1525/E1745', 'TRADFRI motion sensor'],
     IkeaMotionSensor
   );
+
+  registerAccessoryClass(
+    'Xiaomi',
+    [
+      'ZNCZ02LM' /*ZH*/,
+      'ZNCZ03LM' /*TW*/,
+      'ZNCZ04LM' /*EU*/,
+      'SP-EUC01' /*EU-Aqara*/,
+      'ZNCZ12LM' /*US*/,
+    ],
+    XiaomiOutlet
+  );
+  registerAccessoryClass(
+    'LUMI',
+    [
+      'ZNCZ02LM' /*ZH*/,
+      'ZNCZ03LM' /*TW*/,
+      'ZNCZ04LM' /*EU*/,
+      'SP-EUC01' /*EU-Aqara*/,
+      'ZNCZ12LM' /*US*/,
+    ],
+    XiaomiOutlet
+  );
+
   registerAccessoryClass('Xiaomi', ['WSDCGQ01LM', 'WSDCGQ11LM'], TempHumiSensor);
   registerAccessoryClass(
     'Xiaomi',


### PR DESCRIPTION
Creates a new class for "Xiaomi Mi power plug"
and registers all the regional versions of this device.

Currently just a straight copy/paste from IkeaTadfriOutlet
but can be expanded in future since these plugs
have voltage/usage sensors and power failure memory.