### PR TITLE
Added Xiaomi Aqara Opple Wireless Switch support for the 2,4,6 Button…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,7 @@ function registerSupportedDevices(): void {
     XiaomiContactSensor
   );
   registerAccessoryClass('Xiaomi', ['GZCGQ01LM'], XiaomiLightIntensitySensor);
-  registerAccessoryClass('Xiaomi', ['WXKG11LM', 'WXKG03LM', 'WXKG12LM'], XiaomiWirelessSwitch);
+  registerAccessoryClass('Xiaomi', ['WXKG11LM', 'WXKG03LM', 'WXKG12LM', 'WXCJKG11LM', 'WXCJKG12LM', 'WXCJKG13LM'], XiaomiWirelessSwitch);
   registerAccessoryClass(
     'LUMI',
     ['lumi.weather', 'lumi.sensor_ht.agl02', 'lumi.sensor_ht'],
@@ -157,6 +157,9 @@ function registerSupportedDevices(): void {
       'lumi.remote.b1acn01',
       'lumi.sensor_86sw1',
       'lumi.remote.b186acn01',
+      'lumi.remote.b286opcn01',
+      'lumi.remote.b486opcn01',
+      'lumi.remote.b686opcn01',
     ],
     XiaomiWirelessSwitch
   );


### PR DESCRIPTION
Added the Xiaomi Aqara Opple Wireless Switches with 2, 4 and 6 Buttons to support these devices.

Links for the 2 Button Switch as an Example:
https://zigbee.blakadder.com/Xiaomi_WXCJKG11LM.html
https://www.zigbee2mqtt.io/devices/WXCJKG11LM.html

This is my first contribution to an open-source Project so please be nice if i oversaw something :) 
Let me know if additional infos are required! 

tr1ng0

EDIT: I only own the 4 Button Version just to let you know that I can't test the other ones 

