### PR TITLE
Fix typo for panId

### DIFF
--- a/src/zigbee/zigBee-controller.ts
+++ b/src/zigbee/zigBee-controller.ts
@@ -99,7 +99,7 @@ export class ZigBeeController {
           0x0c,
           0x0d,
         ],
-        panID: config.panID || 0xffff,
+        panID: config.panId || 0xffff,
         extendedPanID: [0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd],
         channelList: config.channels,
       },


### PR DESCRIPTION
Fixes the typo responsible for always setting 0xFFFF as panID when creating the controller.