### PR TITLE
Fix #69 Problem with Aqara temperature/humidity

### DIFF
--- a/src/builders/humidity-sensor-service-builder.ts
+++ b/src/builders/humidity-sensor-service-builder.ts
@@ -20,12 +20,7 @@ export class HumiditySensorServiceBuilder extends SensorServiceBuilder {
     this.service
       .getCharacteristic(Characteristic.CurrentRelativeHumidity)
       .on(CharacteristicEventTypes.GET, async (callback: CharacteristicGetCallback) => {
-        try {
-          Object.assign(this.state, await this.client.getHumidity(this.device));
-          callback(null, Math.round(this.state.humidity || 0));
-        } catch (e) {
-          callback(e);
-        }
+        callback(null, Math.round(this.state.humidity || 0));
       });
 
     return this;

--- a/src/builders/temperature-sensor-service-builder.ts
+++ b/src/builders/temperature-sensor-service-builder.ts
@@ -20,12 +20,7 @@ export class TemperatureSensorServiceBuilder extends SensorServiceBuilder {
     this.service
       .getCharacteristic(Characteristic.CurrentTemperature)
       .on(CharacteristicEventTypes.GET, async (callback: Callback) => {
-        try {
-          Object.assign(this.state, await this.client.getTemperature(this.device));
-          callback(null, this.state.temperature);
-        } catch (e) {
-          callback(e);
-        }
+        callback(null, this.state.temperature);
       });
 
     return this;


### PR DESCRIPTION
This fixes #69 by no longer polling the device for temperature and humidity. This is obviously not ideal because now the values only update when the sensor decides to submit the readings to homebridge.

Unfortunatily polling doesn't seem possible because zigbee-herdsman-convertes does not provide any `toZigbee` converters and the [zigbee2mqtt documentation](https://www.zigbee2mqtt.io/devices/WSDCGQ11LM.html) for Aqara temperature and humidity sensors states: 
_"It’s not possible to read (/get) or write (/set) this value."_

This was tested with an Aqara WSDCGQ11LM.