### PR TITLE
Add2and6 button aqara opple switch

### DIFF
--- a/src/accessories/xiaomi/aqara-opple-switch.ts
+++ b/src/accessories/xiaomi/aqara-opple-switch.ts
@@ -3,7 +3,7 @@ import { Service } from 'homebridge';
 import { DeviceState } from '../../zigbee/types';
 import { ProgrammableSwitchServiceBuilder } from '../../builders/programmable-switch-service-builder';
 
-export class AqaraOppleSwitch6Button extends ZigBeeAccessory {
+export class AqaraOppleSwitch6Buttons extends ZigBeeAccessory {
   protected switchServiceTopLeft: Service;
   protected switchServiceTopRight: Service;
   protected switchServiceMiddleLeft: Service;

--- a/src/accessories/xiaomi/aqara-opple-switch.ts
+++ b/src/accessories/xiaomi/aqara-opple-switch.ts
@@ -3,7 +3,181 @@ import { Service } from 'homebridge';
 import { DeviceState } from '../../zigbee/types';
 import { ProgrammableSwitchServiceBuilder } from '../../builders/programmable-switch-service-builder';
 
-export class AqaraOppleSwitch extends ZigBeeAccessory {
+export class AqaraOppleSwitch6Button extends ZigBeeAccessory {
+  protected switchServiceTopLeft: Service;
+  protected switchServiceTopRight: Service;
+  protected switchServiceMiddleLeft: Service;
+  protected switchServiceMiddleRight: Service;
+  protected switchServiceBottomLeft: Service;
+  protected switchServiceBottomRight: Service;
+  protected batteryService: Service;
+
+  getAvailableServices(): Service[] {
+    const builder = new ProgrammableSwitchServiceBuilder(
+      this.platform,
+      this.accessory,
+      this.client,
+      this.state
+    );
+    const ProgrammableSwitchEvent = this.platform.Characteristic.ProgrammableSwitchEvent;
+    [   
+        this.switchServiceMiddleLeft,
+        this.switchServiceMiddleRight,
+        this.switchServiceBottomLeft, 
+        this.switchServiceBottomRight,
+        this.switchServiceTopLeft,
+        this.switchServiceTopRight,
+        this.batteryService,
+    ] = builder
+      .withStatelessSwitch('bottom left', 'top_left', 5, [
+        ProgrammableSwitchEvent.SINGLE_PRESS,
+        ProgrammableSwitchEvent.DOUBLE_PRESS,
+        ProgrammableSwitchEvent.LONG_PRESS,
+      ])
+      .withStatelessSwitch('bottom right', 'top_right', 6, [
+        ProgrammableSwitchEvent.SINGLE_PRESS,
+        ProgrammableSwitchEvent.DOUBLE_PRESS,
+        ProgrammableSwitchEvent.LONG_PRESS,
+      ])
+      .withStatelessSwitch('top left', 'bottom_left', 1, [
+        ProgrammableSwitchEvent.SINGLE_PRESS,
+        ProgrammableSwitchEvent.DOUBLE_PRESS,
+        ProgrammableSwitchEvent.LONG_PRESS,
+      ])
+      .withStatelessSwitch('top right', 'bottom_right', 2, [
+        ProgrammableSwitchEvent.SINGLE_PRESS,
+        ProgrammableSwitchEvent.DOUBLE_PRESS,
+        ProgrammableSwitchEvent.LONG_PRESS,
+      ])
+      .withStatelessSwitch('middle left', 'middle_left', 3, [
+        ProgrammableSwitchEvent.SINGLE_PRESS,
+        ProgrammableSwitchEvent.DOUBLE_PRESS,
+        ProgrammableSwitchEvent.LONG_PRESS,
+      ])
+      .withStatelessSwitch('middle right', 'middle_right', 4, [
+        ProgrammableSwitchEvent.SINGLE_PRESS,
+        ProgrammableSwitchEvent.DOUBLE_PRESS,
+        ProgrammableSwitchEvent.LONG_PRESS,
+      ])
+      .andBattery()
+      .build();
+
+    return [
+        this.switchServiceBottomLeft, 
+        this.switchServiceBottomRight,
+        this.switchServiceTopLeft,
+        this.switchServiceTopRight,
+        this.switchServiceMiddleLeft,
+        this.switchServiceMiddleRight,
+        this.batteryService
+    ];
+  }
+
+  update(state: DeviceState) {
+    super.update(state);
+    const ProgrammableSwitchEvent = this.platform.Characteristic.ProgrammableSwitchEvent;
+    switch (state.action) {
+    //single press
+      case 'button_1_single':
+        this.switchServiceTopLeft
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.SINGLE_PRESS);
+        break;
+      case 'button_2_single':
+        this.switchServiceTopRight
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.SINGLE_PRESS);
+        break;
+      case 'button_3_single':
+        this.switchServiceMiddleLeft
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.SINGLE_PRESS);
+        break;
+      case 'button_4_single':
+        this.switchServiceMiddleRight
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.SINGLE_PRESS);
+        break;
+      case 'button_5_single':
+        this.switchServiceBottomLeft
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.SINGLE_PRESS);
+        break;
+      case 'button_6_single':
+        this.switchServiceBottomRight
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.SINGLE_PRESS);
+        break;
+    
+        
+    //double press
+      case 'button_1_double':
+        this.switchServiceTopLeft
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.DOUBLE_PRESS);
+        break;
+      case 'button_2_double':
+        this.switchServiceTopRight
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.DOUBLE_PRESS);
+        break;
+      case 'button_3_double':
+        this.switchServiceMiddleLeft
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.DOUBLE_PRESS);
+        break;
+      case 'button_4_double':
+        this.switchServiceMiddleRight
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.DOUBLE_PRESS);
+        break;
+      case 'button_5_double':
+        this.switchServiceBottomLeft
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.DOUBLE_PRESS);
+        break;
+      case 'button_6_double':
+        this.switchServiceBottomRight
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.DOUBLE_PRESS);
+        break;
+    //long press
+      case 'button_1_hold':
+        this.switchServiceTopLeft
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.LONG_PRESS);
+        break;
+      case 'button_2_hold':
+        this.switchServiceTopRight
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.LONG_PRESS);
+        break;
+      case 'button_3_hold':
+        this.switchServiceMiddleLeft
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.LONG_PRESS);
+        break;
+      case 'button_4_hold':
+        this.switchServiceMiddleRight
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.LONG_PRESS);
+        break;
+       case 'button_5_hold':
+        this.switchServiceBottomLeft
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.LONG_PRESS);
+        break;
+      case 'button_6_hold':
+        this.switchServiceBottomRight
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.LONG_PRESS);
+        break;
+
+    }
+  }
+}
+
+export class AqaraOppleSwitch4Buttons extends ZigBeeAccessory {
   protected switchServiceTopLeft: Service;
   protected switchServiceTopRight: Service;
   protected switchServiceBottomLeft: Service;
@@ -27,22 +201,22 @@ export class AqaraOppleSwitch extends ZigBeeAccessory {
         this.switchServiceTopRight,
         this.batteryService,
     ] = builder
-      .withStatelessSwitch('bottom left', 'top_left', 3, [
+      .withStatelessSwitch('button_1', 'top_left', 3, [
         ProgrammableSwitchEvent.SINGLE_PRESS,
         ProgrammableSwitchEvent.DOUBLE_PRESS,
         ProgrammableSwitchEvent.LONG_PRESS,
       ])
-      .withStatelessSwitch('bottom right', 'top_right', 4, [
+      .withStatelessSwitch('button_2', 'top_right', 4, [
         ProgrammableSwitchEvent.SINGLE_PRESS,
         ProgrammableSwitchEvent.DOUBLE_PRESS,
         ProgrammableSwitchEvent.LONG_PRESS,
       ])
-      .withStatelessSwitch('top left', 'bottom_left', 1, [
+      .withStatelessSwitch('button_3', 'bottom_left', 1, [
         ProgrammableSwitchEvent.SINGLE_PRESS,
         ProgrammableSwitchEvent.DOUBLE_PRESS,
         ProgrammableSwitchEvent.LONG_PRESS,
       ])
-      .withStatelessSwitch('top right', 'bottom_right', 2, [
+      .withStatelessSwitch('button_4', 'bottom_right', 2, [
         ProgrammableSwitchEvent.SINGLE_PRESS,
         ProgrammableSwitchEvent.DOUBLE_PRESS,
         ProgrammableSwitchEvent.LONG_PRESS,
@@ -130,3 +304,85 @@ export class AqaraOppleSwitch extends ZigBeeAccessory {
     }
   }
 }
+
+export class AqaraOppleSwitch2Buttons extends ZigBeeAccessory {
+  protected switchServiceTopLeft: Service;
+  protected switchServiceTopRight: Service;
+  protected batteryService: Service;
+
+  getAvailableServices(): Service[] {
+    const builder = new ProgrammableSwitchServiceBuilder(
+      this.platform,
+      this.accessory,
+      this.client,
+      this.state
+    );
+
+    const ProgrammableSwitchEvent = this.platform.Characteristic.ProgrammableSwitchEvent;
+
+    [   
+        this.switchServiceTopLeft,
+        this.switchServiceTopRight,
+        this.batteryService,
+    ] = builder
+      .withStatelessSwitch('button_1', 'top_left', 1, [
+        ProgrammableSwitchEvent.SINGLE_PRESS,
+        ProgrammableSwitchEvent.DOUBLE_PRESS,
+        ProgrammableSwitchEvent.LONG_PRESS,
+      ])
+      .withStatelessSwitch('button_2', 'top_right', 2, [
+        ProgrammableSwitchEvent.SINGLE_PRESS,
+        ProgrammableSwitchEvent.DOUBLE_PRESS,
+        ProgrammableSwitchEvent.LONG_PRESS,
+      ])
+      .andBattery()
+      .build();
+
+    return [
+        this.switchServiceTopLeft,
+        this.switchServiceTopRight,
+        this.batteryService
+    ];
+  }
+
+  update(state: DeviceState) {
+    super.update(state);
+    const ProgrammableSwitchEvent = this.platform.Characteristic.ProgrammableSwitchEvent;
+    switch (state.action) {
+    //single press
+      case 'button_1_single':
+        this.switchServiceTopLeft
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.SINGLE_PRESS);
+        break;
+      case 'button_2_single':
+        this.switchServiceTopRight
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.SINGLE_PRESS);
+        break;
+    //double press
+      case 'button_1_double':
+        this.switchServiceTopLeft
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.DOUBLE_PRESS);
+        break;
+      case 'button_2_double':
+        this.switchServiceTopRight
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.DOUBLE_PRESS);
+        break;
+      //long press
+      case 'button_1_hold':
+        this.switchServiceTopLeft
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.LONG_PRESS);
+        break;
+      case 'button_2_hold':
+        this.switchServiceTopRight
+          .getCharacteristic(ProgrammableSwitchEvent)
+          .setValue(ProgrammableSwitchEvent.LONG_PRESS);
+        break;
+    }
+  }
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,9 @@ import { XiaomiWirelessSwitch } from './accessories/xiaomi/xiaomi-wireless-switc
 import { SonoffContactSensor } from './accessories/sonoff/contact-sensor';
 import { IkeaShurtcutSwitch } from './accessories/ikea/ikea-shurtcut-switch';
 import { XiaomiMotionIlluminanceSensor } from './accessories/xiaomi/xiaomi-motion-illuminance-sensor';
-import { AqaraOppleSwitch } from './accessories/xiaomi/aqara-opple-switch';
+import { AqaraOppleSwitch2Buttons } from './accessories/xiaomi/aqara-opple-switch';
+import { AqaraOppleSwitch4Buttons } from './accessories/xiaomi/aqara-opple-switch';
+import { AqaraOppleSwitch6Button } from './accessories/xiaomi/aqara-opple-switch';
 import { NanoleafIvy } from './accessories/nanoleaf/nanoleaf-ivy';
 import { DATABASE_ACCESSORIES } from './accessories/database';
 import { ConfigurableAccessory } from './accessories/configurable-accessory';
@@ -143,7 +145,9 @@ function registerSupportedDevices(): void {
   );
   registerAccessoryClass('Xiaomi', ['GZCGQ01LM'], XiaomiLightIntensitySensor);
   registerAccessoryClass('Xiaomi', ['WXKG11LM', 'WXKG03LM', 'WXKG12LM'], XiaomiWirelessSwitch);
-  registerAccessoryClass('Xiaomi', ['WXCJKG11LM', 'WXCJKG12LM', 'WXCJKG13LM'], AqaraOppleSwitch);
+  registerAccessoryClass('Xiaomi', ['WXCJKG11LM'], AqaraOppleSwitch2Button);
+  registerAccessoryClass('Xiaomi', ['WXCJKG12LM'], AqaraOppleSwitch4Buttons);
+  registerAccessoryClass('Xiaomi', ['WXCJKG13LM'], AqaraOppleSwitch6Button);
   registerAccessoryClass(
     'LUMI',
     ['lumi.weather', 'lumi.sensor_ht.agl02', 'lumi.sensor_ht'],
@@ -168,8 +172,18 @@ function registerSupportedDevices(): void {
   );
   registerAccessoryClass(
     'LUMI',
-    ['lumi.remote.b286opcn01', 'lumi.remote.b486opcn01', 'lumi.remote.b686opcn01'],
-    AqaraOppleSwitch
+    ['lumi.remote.b286opcn01'],
+    AqaraOppleSwitch2Button
+  );
+  registerAccessoryClass(
+    'LUMI',
+    ['lumi.remote.b486opcn01'],
+    AqaraOppleSwitch4Buttons
+  );
+  registerAccessoryClass(
+    'LUMI',
+    ['lumi.remote.b686opcn01'],
+    AqaraOppleSwitch6Button
   );
   registerAccessoryClass('LUMI', ['lumi.sensor_motion'], XiaomiMotionSensor);
   registerAccessoryClass('Xiaomi', ['lumi.sensor_motion'], XiaomiMotionSensor);

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ import { IkeaShurtcutSwitch } from './accessories/ikea/ikea-shurtcut-switch';
 import { XiaomiMotionIlluminanceSensor } from './accessories/xiaomi/xiaomi-motion-illuminance-sensor';
 import { AqaraOppleSwitch2Buttons } from './accessories/xiaomi/aqara-opple-switch';
 import { AqaraOppleSwitch4Buttons } from './accessories/xiaomi/aqara-opple-switch';
-import { AqaraOppleSwitch6Button } from './accessories/xiaomi/aqara-opple-switch';
+import { AqaraOppleSwitch6Buttons } from './accessories/xiaomi/aqara-opple-switch';
 import { NanoleafIvy } from './accessories/nanoleaf/nanoleaf-ivy';
 import { DATABASE_ACCESSORIES } from './accessories/database';
 import { ConfigurableAccessory } from './accessories/configurable-accessory';
@@ -145,9 +145,9 @@ function registerSupportedDevices(): void {
   );
   registerAccessoryClass('Xiaomi', ['GZCGQ01LM'], XiaomiLightIntensitySensor);
   registerAccessoryClass('Xiaomi', ['WXKG11LM', 'WXKG03LM', 'WXKG12LM'], XiaomiWirelessSwitch);
-  registerAccessoryClass('Xiaomi', ['WXCJKG11LM'], AqaraOppleSwitch2Button);
+  registerAccessoryClass('Xiaomi', ['WXCJKG11LM'], AqaraOppleSwitch2Buttons);
   registerAccessoryClass('Xiaomi', ['WXCJKG12LM'], AqaraOppleSwitch4Buttons);
-  registerAccessoryClass('Xiaomi', ['WXCJKG13LM'], AqaraOppleSwitch6Button);
+  registerAccessoryClass('Xiaomi', ['WXCJKG13LM'], AqaraOppleSwitch6Buttons);
   registerAccessoryClass(
     'LUMI',
     ['lumi.weather', 'lumi.sensor_ht.agl02', 'lumi.sensor_ht'],
@@ -173,7 +173,7 @@ function registerSupportedDevices(): void {
   registerAccessoryClass(
     'LUMI',
     ['lumi.remote.b286opcn01'],
-    AqaraOppleSwitch2Button
+    AqaraOppleSwitch2Buttons
   );
   registerAccessoryClass(
     'LUMI',
@@ -183,7 +183,7 @@ function registerSupportedDevices(): void {
   registerAccessoryClass(
     'LUMI',
     ['lumi.remote.b686opcn01'],
-    AqaraOppleSwitch6Button
+    AqaraOppleSwitch6Buttons
   );
   registerAccessoryClass('LUMI', ['lumi.sensor_motion'], XiaomiMotionSensor);
   registerAccessoryClass('Xiaomi', ['lumi.sensor_motion'], XiaomiMotionSensor);


### PR DESCRIPTION
Added support for the 2 and 6 Button version of the Aqara Opple Wirless Switch

I know this is THE worst approach for handling different devices with seperate classes but I am loaded with work and this is the quickest (but dirtiest) fix for supporting these devives, will try to change that when i got time (which will be hopefully in march lol). Sorry!

Regards,
Abel