### PR TITLE
[v2.0.2-unstable-9] Add missing ws dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-zigbee-nt",
-  "version": "2.0.2-unstable-8",
+  "version": "2.0.2-unstable-9",
   "description": "ZigBee New Technology Platform plugin for HomeBridge",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "serialport": "^9.0.2",
     "serve-static": "^1.14.1",
     "winston": "^3.3.3",
+    "ws": "^7.4.2",
     "zigbee-herdsman": "^0.13.59",
     "zigbee-herdsman-converters": "^14.0.34"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10073,7 +10073,7 @@ ws@^6.1.2:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7.2.3:
+ws@^7.2.3, ws@^7.4.2:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.2.tgz#782100048e54eb36fe9843363ab1c68672b261dd"
   integrity sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==


### PR DESCRIPTION
After I installed unstable-8 homebridge crashed because `ws` coud not be found

```
ERROR LOADING PLUGIN homebridge-zigbee-nt:
Error: Cannot find module 'ws'
Require stack:
- /usr/lib/node_modules/homebridge-zigbee-nt/dist/web/api/http-server.js
- /usr/lib/node_modules/homebridge-zigbee-nt/dist/platform.js
- /usr/lib/node_modules/homebridge-zigbee-nt/dist/index.js
- /usr/lib/node_modules/homebridge/lib/plugin.js
- /usr/lib/node_modules/homebridge/lib/pluginManager.js
- /usr/lib/node_modules/homebridge/lib/api.js
- /usr/lib/node_modules/homebridge/lib/server.js
- /usr/lib/node_modules/homebridge/lib/cli.js
- /usr/lib/node_modules/homebridge/bin/homebridge
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/usr/lib/node_modules/homebridge-zigbee-nt/src/web/api/http-server.ts:9:1)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)