### PR TITLE
[Fix] Dismiss support for _TZE200_2dpplnsn TS0601 thermostat

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
     "serve-static": "^1.14.1",
     "winston": "^3.3.3",
     "ws": "^7.4.2",
-    "zigbee-herdsman": "^0.13.72",
-    "zigbee-herdsman-converters": "^14.0.74"
+    "zigbee-herdsman": "^0.13.75",
+    "zigbee-herdsman-converters": "^14.0.76"
   },
   "devDependencies": {
     "@emotion/eslint-plugin": "^11.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,7 +194,11 @@ export function registerSupportedDevices(): void {
   registerAccessoryClass('NAMRON AS', ['4512704'], NamronSwitch);
   registerAccessoryClass('TuYa', ['TS0601_thermostat'], TuyaThermostatControl);
   registerAccessoryClass('Moes', ['HY369RT'], TuyaThermostatControl);
-  registerAccessoryClass(['_TZE200_ckud7u2l'], ['TS0601'], TuyaThermostatControl);
+  registerAccessoryClass(
+    ['_TZE200_ckud7u2l', '_TZE200_ywdxldoj'],
+    ['TS0601'],
+    TuyaThermostatControl
+  );
   registerAccessoryClass('eWeLink', ['DS01'], SonoffContactSensor);
   registerAccessoryClass('Nanoleaf', ['NL08-0800'], NanoleafIvy);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,11 +194,7 @@ export function registerSupportedDevices(): void {
   registerAccessoryClass('NAMRON AS', ['4512704'], NamronSwitch);
   registerAccessoryClass('TuYa', ['TS0601_thermostat'], TuyaThermostatControl);
   registerAccessoryClass('Moes', ['HY369RT'], TuyaThermostatControl);
-  registerAccessoryClass(
-    ['_TZE200_ckud7u2l', '_TZE200_2dpplnsn'],
-    ['TS0601'],
-    TuyaThermostatControl
-  );
+  registerAccessoryClass(['_TZE200_ckud7u2l'], ['TS0601'], TuyaThermostatControl);
   registerAccessoryClass('eWeLink', ['DS01'], SonoffContactSensor);
   registerAccessoryClass('Nanoleaf', ['NL08-0800'], NanoleafIvy);
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -268,11 +268,10 @@ export class ZigbeeNTHomebridgePlatform implements DynamicPlatformPlugin {
     const model = parseModelName(device.modelID);
     const manufacturer = device.manufacturerName;
     const ieeeAddr = device.ieeeAddr;
-    this.log.info(
-      `Initializing ZigBee device: ${this.getDeviceFriendlyName(
-        ieeeAddr
-      )} - ${model} - ${manufacturer}`
-    );
+    const deviceName: string = `${this.getDeviceFriendlyName(
+      ieeeAddr
+    )} - ${model} - ${manufacturer}`;
+    this.log.info(`Initializing ZigBee device: ${deviceName}`);
 
     if (!isAccessorySupported(device)) {
       this.log.info(
@@ -282,13 +281,17 @@ export class ZigbeeNTHomebridgePlatform implements DynamicPlatformPlugin {
       );
       return null;
     } else {
-      const accessory = this.createHapAccessory(ieeeAddr);
-      const homeKitAccessory = createAccessoryInstance(this, accessory, this.client, device);
-      if (homeKitAccessory) {
-        this.log.info('Registered device:', homeKitAccessory.friendlyName, manufacturer, model);
-        await homeKitAccessory.initialize(); // init services
-        this.homekitAccessories.set(accessory.UUID, homeKitAccessory);
-        return accessory.UUID;
+      try {
+        const accessory = this.createHapAccessory(ieeeAddr);
+        const homeKitAccessory = createAccessoryInstance(this, accessory, this.client, device);
+        if (homeKitAccessory) {
+          this.log.info('Registered device:', homeKitAccessory.friendlyName, manufacturer, model);
+          await homeKitAccessory.initialize(); // init services
+          this.homekitAccessories.set(accessory.UUID, homeKitAccessory);
+          return accessory.UUID;
+        }
+      } catch (e) {
+        this.log.error(`Error initializing device ${deviceName}`, e);
       }
       return null;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1495,6 +1495,18 @@
     "@serialport/binding-abstract" "^9.0.7"
     debug "^4.3.1"
 
+"@serialport/bindings@9.0.4":
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/@serialport/bindings/-/bindings-9.0.4.tgz#c8c24caf32d666a49a47b474ebd3f834f21481b3"
+  integrity sha512-6dlE1vm5c1xk667f1Zm7D+msbHJ9jdnUr9l8DResKpj2iCBzbCNsW+yCYq26WxzXWc1L2HUaS3/aL+k0wm5amg==
+  dependencies:
+    "@serialport/binding-abstract" "^9.0.2"
+    "@serialport/parser-readline" "^9.0.1"
+    bindings "^1.5.0"
+    debug "^4.3.1"
+    nan "^2.14.2"
+    prebuild-install "^6.0.0"
+
 "@serialport/bindings@^9.0.3":
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/@serialport/bindings/-/bindings-9.0.3.tgz#ef46f15920ea454ec53f55ae1e7f3634e1c95883"
@@ -1507,7 +1519,7 @@
     nan "^2.14.2"
     prebuild-install "^6.0.0"
 
-"@serialport/bindings@^9.0.7":
+"@serialport/bindings@^9.0.4", "@serialport/bindings@^9.0.7":
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/@serialport/bindings/-/bindings-9.0.7.tgz#8f53fb56eb866d5a1021a19ced1ddc20a60916d7"
   integrity sha512-cNWaxnEbbpLoSJ6GMb0ZeCpaciczm8XRE4jgBqe/BflWZb+wyiTYIocbsySxpS40WT3kJ0sNTFag77uSmQ6ftg==
@@ -1549,7 +1561,7 @@
   resolved "https://registry.yarnpkg.com/@serialport/parser-delimiter/-/parser-delimiter-9.0.7.tgz#7bef2447d4282dd00dc659719b310edeb30ff294"
   integrity sha512-Vb2NPeXPZ/28M4m5x4OAHFd8jRAeddNCgvL+Q+H/hqFPY1w47JcMLchC7pigRW8Cnt1fklmzfwdNQ8Fb+kMkxQ==
 
-"@serialport/parser-inter-byte-timeout@^9.0.7":
+"@serialport/parser-inter-byte-timeout@^9.0.1", "@serialport/parser-inter-byte-timeout@^9.0.7":
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-9.0.7.tgz#55b315b49d8ad37f981ba69bb9443f25c96aec17"
   integrity sha512-lUZ3cwgUluBvJ1jf+0LQsqoiPYAokDO6+fRCw9HCfnrF/OS60Gm4rxuyo2uQIueqZkJ7NIFP+ibKsULrA47AEA==
@@ -8983,6 +8995,23 @@ serialize-to-js@^3.0.0:
   resolved "https://registry.yarnpkg.com/serialize-to-js/-/serialize-to-js-3.1.1.tgz#b3e77d0568ee4a60bfe66287f991e104d3a1a4ac"
   integrity sha512-F+NGU0UHMBO4Q965tjw7rvieNVjlH6Lqi2emq/Lc9LUURYJbiCzmpi4Cy1OOjjVPtxu0c+NE85LU6968Wko5ZA==
 
+serialport@9.0.6:
+  version "9.0.6"
+  resolved "https://registry.yarnpkg.com/serialport/-/serialport-9.0.6.tgz#3b0bd8ce6a230566aab56ecb9d3556e7c3b5d889"
+  integrity sha512-T9eY4HFzQij0Hd/RsPcZySdeuAqzV5iGICHz8FXUSKVn2SvGT5zjfz/H+pRwI86k+3iFVOyddEyy8gbVNVbW7A==
+  dependencies:
+    "@serialport/binding-mock" "^9.0.2"
+    "@serialport/bindings" "^9.0.4"
+    "@serialport/parser-byte-length" "^9.0.1"
+    "@serialport/parser-cctalk" "^9.0.1"
+    "@serialport/parser-delimiter" "^9.0.1"
+    "@serialport/parser-inter-byte-timeout" "^9.0.1"
+    "@serialport/parser-readline" "^9.0.1"
+    "@serialport/parser-ready" "^9.0.1"
+    "@serialport/parser-regex" "^9.0.1"
+    "@serialport/stream" "^9.0.2"
+    debug "^4.1.1"
+
 serialport@9.0.7:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/serialport/-/serialport-9.0.7.tgz#bd116a70bd7acbfd587491acd3ee03e02a0df71c"
@@ -10548,10 +10577,10 @@ yn@3.1.1:
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
-zigbee-herdsman-converters@^14.0.74:
-  version "14.0.74"
-  resolved "https://registry.yarnpkg.com/zigbee-herdsman-converters/-/zigbee-herdsman-converters-14.0.74.tgz#e047245234b80d9e431d0e49b7e8f73690bfaca5"
-  integrity sha512-h0pX0ERRTtpDcVNni3g5DqHc305TV9lS1JgJ6x+n5jCNyvjJq9kSuvhnLLbmst9JMsSxTiE1AEdDbWmMDX/qCg==
+zigbee-herdsman-converters@^14.0.76:
+  version "14.0.76"
+  resolved "https://registry.yarnpkg.com/zigbee-herdsman-converters/-/zigbee-herdsman-converters-14.0.76.tgz#462529cf47c8540713a019ae9988e9cc462b1f68"
+  integrity sha512-vQfgA0owalFO69r7hXq0/ZX6pPSnrPN/QLRlYoYRTpociJ+Bi++TNEIsSdHJ+DemiIhZLzBuwgWT3wGVs3sotQ==
   dependencies:
     axios "^0.21.1"
     buffer-crc32 "^0.2.13"
@@ -10569,4 +10598,17 @@ zigbee-herdsman@^0.13.72:
     fast-deep-equal "^3.1.3"
     mixin-deep "^2.0.1"
     serialport "9.0.7"
+    slip "^1.0.2"
+
+zigbee-herdsman@^0.13.75:
+  version "0.13.75"
+  resolved "https://registry.yarnpkg.com/zigbee-herdsman/-/zigbee-herdsman-0.13.75.tgz#0d8084a7696eba03549c6345e1873dbfb8999267"
+  integrity sha512-hOy7kdqRFq7cQBCINe0VTZjTnpGlIFfP+ubd/PVd1Lg0TmpGbZfUUzZdbf2eRHAYFucfZ90DV0Tq1sNtbkBhcQ==
+  dependencies:
+    "@serialport/bindings" "9.0.4"
+    debounce "^1.2.0"
+    debug "^4.3.1"
+    fast-deep-equal "^3.1.3"
+    mixin-deep "^2.0.1"
+    serialport "9.0.6"
     slip "^1.0.2"


### PR DESCRIPTION
- Device _TZE200_2dpplnsn TS0601 is not compatible with herdsman lib, removing from supported accessories
- Add support for _TZE200_ywdxldoj.TS0601 thermostat (same as _TZE200_ckud7u2l.TS0601)
- Add a try/catch during accessory initialisation to avoid plugin problems at startup
- Updated dependencies