### PR TITLE
Fix isUpdateFirmwareAvailable to pass null for no request payload

### DIFF
--- a/src/zigbee/zig-bee-client.ts
+++ b/src/zigbee/zig-bee-client.ts
@@ -475,7 +475,7 @@ export class ZigBeeClient {
     return this.zigBee.getCoordinatorVersion();
   }
 
-  async isUpdateFirmwareAvailable(device: Device, request = {}): Promise<boolean> {
+  async isUpdateFirmwareAvailable(device: Device, request = null): Promise<boolean> {
     const zigBeeEntity = this.zigBee.resolveEntity(device);
     if (zigBeeEntity.definition.ota) {
       return zigBeeEntity.definition.ota.isUpdateAvailable(device, this.log, request);


### PR DESCRIPTION
Passing {} instead of null caused a failure as the request payload wasn’t looked up so an undefined imageType was used.