### PR TITLE
Add OTA capability to the UI

### DIFF
--- a/src/web/ui/actions/devices.ts
+++ b/src/web/ui/actions/devices.ts
@@ -137,7 +137,7 @@ export class DevicesService {
     }
   }
 
-  static async checkForUpdates(ieeeAddr: string) {
+  static async checkForUpdates(ieeeAddr: string): Promise<boolean> {
     const response = await fetch(`/api/devices/${ieeeAddr}/checkForUpdates`, {
       method: 'GET',
       headers: {
@@ -146,10 +146,13 @@ export class DevicesService {
     });
     if (response.ok) {
       const json = await response.json();
-      return {
-        result: 'success',
-        state: json,
-      };
+      if (json.newFirmwareAvailable === 'YES') {
+        return true;
+      } else if (json.newFirmwareAvailable === 'NO') {
+        return false;
+      } else {
+        throw new Error(`Failed to determine updates status: ${JSON.stringify(json)}`)
+      }
     } else {
       throw new Error(await response.text());
     }


### PR DESCRIPTION
I had a few bulbs that were nine years without a bridge and so I became interested in OTA updates. I don't think I've done a beautiful job with this, but I wanted to see the status and to be able to update the device from the web UI.

I didn't come up with a beautiful solution for monitoring the OTA update... and the chunked output in plain text doesn't update as frequently as I'd like in Safari. Any better ideas?