### PR TITLE
Lightbulb xy fix

### DIFF
--- a/src/builders/lighbulb-service-builder.ts
+++ b/src/builders/lighbulb-service-builder.ts
@@ -157,7 +157,7 @@ export class LighbulbServiceBuilder extends ServiceBuilder {
           try {
             if (this.isOnline) {
               Object.assign(this.state, await this.client.setHue(this.device, hue));
-              return callback();
+              return callback(null, get(this.state, 'color.hue', 360));
             } else {
               return callback(new Error('Device is offline'));
             }

--- a/src/builders/lighbulb-service-builder.ts
+++ b/src/builders/lighbulb-service-builder.ts
@@ -209,17 +209,29 @@ export class LighbulbServiceBuilder extends ServiceBuilder {
       hue: 360,
     };
 
+    const updateClientColor = async () => {
+      const hsb = new HSBType(
+        this.state.color.hue,
+        this.state.color.s,
+        this.state.brightness_percent
+      );
+      const [x, y] = hsb.toXY();
+      const state = await this.client.setColorXY(this.device, x, y);
+      const resultHsbType = HSBType.fromXY(state.color.x, state.color.y);
+      this.state.color.hue = resultHsbType.hue;
+      this.state.color.s = resultHsbType.saturation;
+    };
+
     this.service
       .getCharacteristic(Characteristic.Hue)
       .on(CharacteristicEventTypes.SET, async (h: number, callback: CharacteristicSetCallback) => {
         try {
           if (this.isOnline) {
-            const s = this.service.getCharacteristic(Characteristic.Saturation).value as number;
-            const v = this.service.getCharacteristic(Characteristic.Brightness).value as number;
-            const hsbType = new HSBType(h, s, v);
-            const [r, g, b] = hsbType.toRGB();
-            await this.client.setColorRGB(this.device, r, g, b);
-            return callback();
+            /* Update state immediately so other requests use the latest settings */
+            this.state.color.hue = h;
+
+            await updateClientColor();
+            return callback(null, get(this.state, 'color.hue', 360));
           } else {
             return callback(new Error('Device is offline'));
           }
@@ -231,8 +243,8 @@ export class LighbulbServiceBuilder extends ServiceBuilder {
       .getCharacteristic(Characteristic.Hue)
       .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
         if (this.isOnline) {
+          /* Trigger read that will be reported later by internalUpdate */
           this.client.getColorXY(this.device).catch(e => this.log.error(e.message));
-          this.log.debug(`Reading HUE for ${this.friendlyName}: ${this.state.color.hue}`);
           return callback(null, get(this.state, 'color.hue', 360));
         } else {
           return callback(new Error('Device is offline'));
@@ -246,12 +258,11 @@ export class LighbulbServiceBuilder extends ServiceBuilder {
         async (saturation: number, callback: CharacteristicSetCallback) => {
           try {
             if (this.isOnline) {
-              const v = this.service.getCharacteristic(Characteristic.Brightness).value as number;
-              const hue = this.service.getCharacteristic(Characteristic.Hue).value as number;
-              const hsbType = new HSBType(hue, saturation, v);
-              const [r, g, b] = hsbType.toRGB();
-              await this.client.setColorRGB(this.device, r, g, b);
-              return callback();
+              /* Update state immediately so other requests use the latest settings */
+              this.state.color.s = saturation;
+
+              await updateClientColor();
+              return callback(null, get(this.state, 'color.s', 100));
             } else {
               return callback(new Error('Device is offline'));
             }
@@ -264,6 +275,7 @@ export class LighbulbServiceBuilder extends ServiceBuilder {
       .getCharacteristic(Characteristic.Saturation)
       .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
         if (this.isOnline) {
+          /* Trigger read that will be reported later by internalUpdate */
           this.client.getColorXY(this.device).catch(e => this.log.error(e.message));
           return callback(null, get(this.state, 'color.s', 100));
         } else {
@@ -278,8 +290,14 @@ export class LighbulbServiceBuilder extends ServiceBuilder {
         async (brightnessPercent: number, callback: CharacteristicSetCallback) => {
           try {
             if (this.isOnline) {
-              await this.client.setBrightnessPercent(this.device, brightnessPercent);
-              return callback();
+              /* Update state immediately so other requests use the latest settings */
+              this.state.brightness_percent = brightnessPercent;
+
+              Object.assign(
+                this.state,
+                await this.client.setBrightnessPercent(this.device, brightnessPercent)
+              );
+              return callback(null, get(this.state, 'brightness_percent', 100));
             } else {
               return callback(new Error('Device is offline'));
             }
@@ -292,12 +310,8 @@ export class LighbulbServiceBuilder extends ServiceBuilder {
       .getCharacteristic(Characteristic.Brightness)
       .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
         if (this.isOnline) {
-          this.client.getBrightnessPercent(this.device).catch(e => {
-            this.log.error(e.message);
-          });
-          this.log.debug(
-            `Reading Brightness for ${this.friendlyName}: ${this.state.brightness_percent}`
-          );
+          /* Trigger read that will be reported later by internalUpdate */
+          this.client.getBrightnessPercent(this.device).catch(e => this.log.error(e.message));
           return callback(null, get(this.state, 'brightness_percent', 100));
         } else {
           return callback(new Error('Device is offline'));

--- a/src/utils/hsb-type.ts
+++ b/src/utils/hsb-type.ts
@@ -284,7 +284,7 @@ export class HSBType {
     const x = tmpX / (tmpX + tmpY + tmpZ);
     const y = tmpY / (tmpX + tmpY + tmpZ);
 
-    return [x * 100.0, y * 100.0, tmpY * this.brightness];
+    return [x, y, tmpY * this.brightness];
   }
 
   private validateValue(hue: number, saturation: number, brightness: number): void {


### PR DESCRIPTION
Resolves #169 

Lightbulbs with xy support turn hue, saturation and brightness into an xy value to send to the lightbulb. Homebridge / HomeKit sends hue and saturation changes as separate requests. The previous implementation suffered from a race condition as the separate hue and saturation set requests were not aware of each other, wouldn’t see the change each other had made due to timing (as the result was only stored once it had succeeded), and would therefore overwrite each other's changes.

This PR standardises the approach in getters and setters in lightbulb-service-builder's xy implementation. It updates its internal state _before_ sending instructions to the bulb, and it uses its internal state for building a new `setColorXY` request, so each request builds upon the previous rather than losing previous changes.

This PR also uses `setColorXY` instead of `setColorRGB`, now that the result of `HSBType.toXY()` has been corrected (see 9489747a6806a9bd7b302a076277bcb52ecc7959).

This PR also adds a couple of comments explaining why when asked for something like the current hue, we send the Zigbee request but don't wait for the result!

This completely corrects the behaviour of my Philips Hue bulbs. Before this change, asking Siri to make a change would >50% of the time result in a flash to the new state then back to the old (due to the race condition explained above). Now the changes work 100% of the time.