### PR TITLE
Add Aqara Cube

### DIFF
--- a/src/accessories/xiaomi/aqara-cube.ts
+++ b/src/accessories/xiaomi/aqara-cube.ts
@@ -1,0 +1,118 @@
+import { Service } from 'homebridge';
+import { BatteryServiceBuilder } from '../../builders/battery-service-builder';
+import { ProgrammableSwitchServiceBuilder } from '../../builders/programmable-switch-service-builder';
+import { DeviceState } from '../../zigbee/types';
+import { ZigBeeAccessory } from '../zig-bee-accessory';
+
+interface Button {
+  index: number;
+  displayName: string;
+  subType: string;
+}
+
+export class AqaraCube extends ZigBeeAccessory {
+  protected services: Service[];
+  protected buttons: Button[] = [
+    {
+      index: 1,
+      displayName: 'shake',
+      subType: 'shake',
+    },
+    {
+      index: 2,
+      displayName: 'fall',
+      subType: 'fall',
+    },
+    {
+      index: 3,
+      displayName: 'tap',
+      subType: 'tap',
+    },
+    {
+      index: 4,
+      displayName: 'slide',
+      subType: 'slide',
+    },
+    {
+      index: 5,
+      displayName: 'flip 180',
+      subType: 'flip180',
+    },
+    {
+      index: 6,
+      displayName: 'flip 90',
+      subType: 'flip90',
+    },
+    {
+      index: 7,
+      displayName: 'rotate left',
+      subType: 'rotate_left',
+    },
+    {
+      index: 8,
+      displayName: 'rotate right',
+      subType: 'rotate_right',
+    },
+  ];
+  protected batteryService: Service;
+
+  getAvailableServices(): Service[] {
+    const builder = new ProgrammableSwitchServiceBuilder(
+      this.platform,
+      this.accessory,
+      this.client,
+      this.state
+    );
+
+    this.buttons.forEach((button) => {
+      builder.withStatelessSwitch(button.displayName, button.subType, button.index, [
+        this.platform.Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS,
+      ]);
+    });
+
+    this.services = builder.build();
+
+    this.batteryService = new BatteryServiceBuilder(
+      this.platform,
+      this.accessory,
+      this.client,
+      this.state
+    )
+      .withBatteryPercentage()
+      .build();
+    this.services.push(this.batteryService);
+
+    return this.services;
+  }
+
+  update(state: DeviceState) {
+    this.batteryService.updateCharacteristic(
+      this.platform.Characteristic.BatteryLevel,
+      state.battery || 0
+    );
+    this.batteryService.updateCharacteristic(
+      this.platform.Characteristic.StatusLowBattery,
+      state.battery && state.battery < 10
+    );
+
+    if (this.state.action == undefined) {
+      return;
+    }
+
+    // get index of switchService by checking if button.subType matches the button from action
+    const switchServiceIndex = this.buttons.findIndex(
+      (button) => button.subType === this.state.action
+    );
+
+    // just to be sure probably not needed ¯\_(ツ)_/¯
+    if (switchServiceIndex < 0) {
+      return;
+    }
+
+    this.services[switchServiceIndex]
+      .getCharacteristic(this.platform.Characteristic.ProgrammableSwitchEvent)
+      .setValue(this.platform.Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS);
+
+    delete this.state.action;
+  }
+}

--- a/src/devices-registration.ts
+++ b/src/devices-registration.ts
@@ -21,6 +21,7 @@ import { PhilipsHueWhiteTemperature } from './accessories/philips/philips-hue-wh
 import { SonoffContactSensor } from './accessories/sonoff/contact-sensor';
 import { TuyaOnoffDoubleSwitch } from './accessories/tuya/tuya-onoff-double-switch';
 import { TuyaThermostatControl } from './accessories/tuya/tuya-thermostat-control';
+import { AqaraCube } from './accessories/xiaomi/aqara-cube';
 import {
   AqaraOppleSwitch2Buttons,
   AqaraOppleSwitch4Buttons,
@@ -173,6 +174,7 @@ export function registerSupportedDevices(): void {
     ],
     XiaomiWirelessSwitch
   );
+  registerAccessoryClass('LUMI', ['lumi.sensor_cube.aqgl01'], AqaraCube);
   registerAccessoryClass('LUMI', ['lumi.remote.b286opcn01'], AqaraOppleSwitch2Buttons);
   registerAccessoryClass('LUMI', ['lumi.remote.b486opcn01'], AqaraOppleSwitch4Buttons);
   registerAccessoryClass('LUMI', ['lumi.remote.b686opcn01'], AqaraOppleSwitch6Buttons);

--- a/src/zigbee/types.ts
+++ b/src/zigbee/types.ts
@@ -86,7 +86,15 @@ export type ButtonAction =
   | 'double_both'
   | 'hold_left'
   | 'hold_right'
-  | 'hold_both';
+  | 'hold_both'
+  | 'shake'
+  | 'fall'
+  | 'tap'
+  | 'slide'
+  | 'flip180'
+  | 'flip90'
+  | 'rotate_left'
+  | 'rotate_right';
 
 export type ClickAction =
   | 'on'


### PR DESCRIPTION
This adds the Aqara Cube compatibility with a single press button for each possible action.
https://www.zigbee2mqtt.io/devices/MFKZQ01LM.html

Tested using CC2652RB USB kit + Homebridge 1.3.6

This fixes partially #29